### PR TITLE
Add Copilot instructions and docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot – Project-specific Guidance
+- For instructions related to Agents, refer to AGENTS.md.
+- For documentation regarding the System, consult the Markdown files located under the /docs directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Agent Instructions
+
+For general guidelines about working with this project, see [docs/DETAILS.md](docs/DETAILS.md).
+
+No automated tests are defined for this repository.

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -1,0 +1,13 @@
+# Repository Documentation
+
+This project contains the sources for the `awesome-irb-theme` site built with Jekyll.
+
+## Building the Site
+
+Run the following command to build or preview the site locally:
+
+```bash
+bundle exec jekyll serve
+```
+
+Refer to this file for more information about project setup and usage.


### PR DESCRIPTION
## Summary
- add GitHub Copilot configuration
- document contributor guidance in AGENTS.md
- provide additional details under docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684407c7c3608329ae1e5f6889b18545